### PR TITLE
fix vcr config

### DIFF
--- a/tests/testthat/setup-tidytags.R
+++ b/tests/testthat/setup-tidytags.R
@@ -26,5 +26,6 @@ invisible(vcr::vcr_configure(
   filter_sensitive_data =
     list("<<<my_opencage_api_key>>>" = Sys.getenv('OPENCAGE_KEY'),
          "<<<my_twitter_api_key>>>" = Sys.getenv('TWITTER_PAT')
-    )
+    ),
+   filter_request_headers = list(Authorization = "<<<not-my-bearer-token>>>")
 ))


### PR DESCRIPTION
then re-record cassettes and check it does indeed replace the Authorization header :-) Also make sure no refresh token gets saved, see e.g. the end of https://github.com/rladies/meetupr/pull/84/files#diff-07985c55c4f441d25a814f5e397bd58a0c463b59f1160f97767111fc5d68cb57

cc @sckott who might have more tips